### PR TITLE
Fixes declaration file reference, makes keyType optional and follow an enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,25 @@
 {
     "type": "module",
     "name": "@neardefi/shade-agent-js",
-    "version": "1.0.0",
-    "main": "index.cjs",
+    "version": "1.0.1",
+    "main": "dist/index.cjs",
     "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.cjs"
+        }
+    },
+    "files": [
+        "dist"
+    ],
     "author": "Matt Lockyer <github.com/mattlockyer>",
     "license": "MIT",
     "scripts": {
         "build:proxy": "cd ./contracts/proxy && RUSTFLAGS='-C link-arg=--enable-bulk-memory' cargo near build non-reproducible-wasm",
         "build:sandbox": "cd ./contracts/sandbox && RUSTFLAGS='-C link-arg=--enable-bulk-memory' cargo near build non-reproducible-wasm",
-        "build": "tsup src/* --format cjs --dts && cp package.json dist/package.json",
-        "build:test": "tsup src/* --format cjs --dts && cp package.json dist/package.json && rm -rf docker-api/dist && mkdir docker-api/dist && cp dist/* docker-api/dist",
+        "build": "tsup src/index.ts --format cjs --dts && cp package.json dist/package.json",
+        "build:test": "yarn run build && rm -rf docker-api/dist && mkdir docker-api/dist && cp dist/* docker-api/dist",
         "deploy": "npm publish --access public",
         "proxy:test": "yarn build:test && yarn build:proxy && node ./scripts/deploy.js",
         "deploy:contract": "node ./scripts/deploy.js"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.ts",
+            "types": "./dist/index.d.cts",
             "require": "./dist/index.cjs"
         }
     },

--- a/src/api.ts
+++ b/src/api.ts
@@ -71,23 +71,28 @@ export const agentView = async (args: ContractArgs): Promise<any> =>
 export const agentCall = async (args: ContractArgs): Promise<any> =>
     agent('call', args);
 
+export enum SignatureKeyType {
+  Eddsa = 'Eddsa',
+  Ecdsa = 'Ecdsa',
+}
+
 /**
  * Requests a digital signature from the agent for a given payload and path.
  *
  * @param {Object} params - The parameters for the signature request.
  * @param {string} params.path - The path associated with the signature request.
  * @param {string} params.payload - The payload to be signed.
- * @param {string} params.keyType - The type of key to use for signing (default is 'Ecdsa').
+ * @param {SignatureKeyType} [params.keyType='Ecdsa'] - The type of key to use for signing (default is 'Ecdsa').
  * @returns A promise that resolves with the result of the signature request.
  */
 export const requestSignature = async ({
     path,
     payload,
-    keyType = 'Ecdsa',
+    keyType = SignatureKeyType.Ecdsa,
 }: {
     path: string;
     payload: string;
-    keyType: string;
+    keyType?: SignatureKeyType;
 }): Promise<any> => {
     return agent('call', {
         methodName: 'request_signature',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "checkJs": false,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This resolves the need to add `declare module` in the shade-agent-template and fixes type declarations showing in IDE

- [x] Sets main to the built `dist/index.cjs`
- [x] Exports the `dist` for npm publish, resolves `types` to proper `index.d.cjs`
- [x] tsup build uses `index.ts` as an entry
- [x] Adds an enum for SignatureKeyType
- [x] Fixes issue with keyType not actually being optional (jsdocs said it defaults, but it was still a required argument)
